### PR TITLE
Event Date and Time

### DIFF
--- a/app/components/shared/event-detail-form.tsx
+++ b/app/components/shared/event-detail-form.tsx
@@ -67,15 +67,17 @@ export default function EventDetailForm({
       />
       <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
         <div className="space-y-2">
-          <FormLabel>Date start</FormLabel>
+          <FormLabel>Start date</FormLabel>
           <DateTimePicker
             className="w-full"
             {...conform.input(dateTimeStart)}
           />
+          <FormErrors>{dateTimeStart}</FormErrors>
         </div>
         <div className="space-y-2">
-          <FormLabel>Date End</FormLabel>
+          <FormLabel>End date</FormLabel>
           <DateTimePicker className="w-full" {...conform.input(dateTimeEnd)} />
+          <FormErrors>{dateTimeEnd}</FormErrors>
         </div>
       </div>
       <div className="grid grid-cols-1 gap-2 md:grid-cols-5">

--- a/app/components/shared/event-detail-form.tsx
+++ b/app/components/shared/event-detail-form.tsx
@@ -12,6 +12,7 @@ import {
 import { type modelEventCategory } from "~/models/event-category.server"
 import { type modelEventFormat } from "~/models/event-format.server"
 import { type modelEventMedia } from "~/models/event-media.server"
+import { DateTimePicker } from "../ui/date-time-picker"
 import {
   Select,
   SelectContent,
@@ -32,6 +33,8 @@ interface EventDetailFormProps {
   mapsUrl: FieldConfig<string>
   mediaId: FieldConfig<string>
   url: FieldConfig<string>
+  dateTimeStart: FieldConfig<Date>
+  dateTimeEnd: FieldConfig<Date>
   eventFormats: Prisma.PromiseReturnType<typeof modelEventFormat.getAll>
   eventMedias: Prisma.PromiseReturnType<typeof modelEventMedia.getAll>
   eventCategories: Prisma.PromiseReturnType<typeof modelEventCategory.getAll>
@@ -47,6 +50,8 @@ export default function EventDetailForm({
   mapsUrl,
   mediaId,
   url,
+  dateTimeStart,
+  dateTimeEnd,
   eventFormats,
   eventMedias,
   eventCategories,
@@ -60,6 +65,19 @@ export default function EventDetailForm({
         name="categoryId"
         defaultValue={categoryId.defaultValue}
       />
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+        <div className="space-y-2">
+          <FormLabel>Date start</FormLabel>
+          <DateTimePicker
+            className="w-full"
+            {...conform.input(dateTimeStart)}
+          />
+        </div>
+        <div className="space-y-2">
+          <FormLabel>Date End</FormLabel>
+          <DateTimePicker className="w-full" {...conform.input(dateTimeEnd)} />
+        </div>
+      </div>
       <div className="grid grid-cols-1 gap-2 md:grid-cols-5">
         {eventFormats.length > 0 && (
           <div

--- a/app/components/shared/event-detail-form.tsx
+++ b/app/components/shared/event-detail-form.tsx
@@ -12,7 +12,7 @@ import {
 import { type modelEventCategory } from "~/models/event-category.server"
 import { type modelEventFormat } from "~/models/event-format.server"
 import { type modelEventMedia } from "~/models/event-media.server"
-import { DateTimePicker } from "../ui/date-time-picker"
+import { DateTimePickerWithRange } from "../ui/date-time-range-picker"
 import {
   Select,
   SelectContent,
@@ -65,20 +65,11 @@ export default function EventDetailForm({
         name="categoryId"
         defaultValue={categoryId.defaultValue}
       />
-      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-        <div className="space-y-2">
-          <FormLabel>Start date</FormLabel>
-          <DateTimePicker
-            className="w-full"
-            {...conform.input(dateTimeStart)}
-          />
-          <FormErrors>{dateTimeStart}</FormErrors>
-        </div>
-        <div className="space-y-2">
-          <FormLabel>End date</FormLabel>
-          <DateTimePicker className="w-full" {...conform.input(dateTimeEnd)} />
-          <FormErrors>{dateTimeEnd}</FormErrors>
-        </div>
+      <div className="space-y-2">
+        <FormLabel>Date</FormLabel>
+        <DateTimePickerWithRange from={dateTimeStart} to={dateTimeEnd} />
+        <FormErrors>{dateTimeStart}</FormErrors>
+        <FormErrors>{dateTimeEnd}</FormErrors>
       </div>
       <div className="grid grid-cols-1 gap-2 md:grid-cols-5">
         {eventFormats.length > 0 && (

--- a/app/components/shared/event-item.tsx
+++ b/app/components/shared/event-item.tsx
@@ -7,7 +7,7 @@ export interface Event {
   slug: string
   title: string
   description: string
-  date: string
+  dateTimeStart: string
   image: {
     url: string
   }
@@ -47,7 +47,7 @@ export function EventItem({ event }: { event: Event }) {
         </div>
 
         <p className="text-sm text-muted-foreground">
-          <time>{formatPublished(event.date)}</time>
+          <time>{formatPublished(event.dateTimeStart)}</time>
         </p>
 
         <ButtonLink variant="secondary" size="sm" to={`/events/${event.slug}`}>

--- a/app/components/ui/date-time-picker.tsx
+++ b/app/components/ui/date-time-picker.tsx
@@ -1,0 +1,80 @@
+import { useInputEvent, type FieldConfig } from "@conform-to/react"
+import { useRef, useState } from "react"
+
+import { Button } from "~/components/ui/button"
+import { Calendar } from "~/components/ui/calendar"
+import { Iconify } from "~/components/ui/iconify"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover"
+import { TimePicker } from "~/components/ui/time-picker"
+import { cn } from "~/utils/cn"
+import { formatDateDMYHS } from "~/utils/datetime"
+
+export function DateTimePicker({
+  className,
+  ...props
+}: {
+  className: string
+} & FieldConfig<string>) {
+  const defaultDate =
+    props.defaultValue && props.defaultValue !== "Invalid Date"
+      ? new Date(props.defaultValue)
+      : new Date()
+
+  const [date, setDate] = useState<Date>(defaultDate)
+  const shadowInputRef = useRef<HTMLInputElement>(null)
+
+  const control = useInputEvent({
+    ref: shadowInputRef,
+    onFocus: () => shadowInputRef.current?.focus(),
+    onReset: () => setDate(defaultDate),
+  })
+  return (
+    <div>
+      <Popover>
+        <input
+          type="hidden"
+          required={props.required}
+          name={props.name}
+          value={String(date)}
+          onChange={event => {
+            control.change(event.target.value)
+            setDate(new Date(event.target.value))
+          }}
+        />
+
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            className={cn(
+              "h-9 justify-start gap-2 border-input p-2 text-left font-normal",
+              !date && "text-muted-foreground",
+              className,
+            )}
+          >
+            <Iconify icon="ph:calendar-blank" className="h-5 w-5" />
+            {date ? formatDateDMYHS(date) : <span>Pick a date</span>}
+          </Button>
+        </PopoverTrigger>
+
+        <PopoverContent className="w-auto p-0">
+          <Calendar
+            initialFocus
+            mode="single"
+            selected={date}
+            onSelect={setDate as any}
+            defaultMonth={date}
+            yearPast={5}
+            yearFuture={5}
+          />
+          <div className="border-t border-border p-3">
+            <TimePicker setDate={setDate as any} date={date} />
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/app/components/ui/date-time-range-picker.tsx
+++ b/app/components/ui/date-time-range-picker.tsx
@@ -1,5 +1,5 @@
 import { type FieldConfig } from "@conform-to/react"
-import addHours from "date-fns/addHours"
+import { addHours } from "date-fns"
 import React from "react"
 import { type DateRange } from "react-day-picker"
 import { cn } from "~/utils/cn"

--- a/app/components/ui/date-time-range-picker.tsx
+++ b/app/components/ui/date-time-range-picker.tsx
@@ -1,0 +1,155 @@
+import { type FieldConfig } from "@conform-to/react"
+import addHours from "date-fns/addHours"
+import React from "react"
+import { type DateRange } from "react-day-picker"
+import { cn } from "~/utils/cn"
+import { formatDateDMYHS } from "~/utils/datetime"
+
+import { Button } from "~/components/ui/button"
+import { Calendar } from "~/components/ui/calendar"
+import { FormLabel } from "~/components/ui/form"
+import { Iconify } from "~/components/ui/iconify"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover"
+import { TimePicker } from "~/components/ui/time-picker"
+
+export function DateTimePickerWithRange({
+  className,
+  from,
+  to,
+}: React.HTMLAttributes<HTMLDivElement> & {
+  from?: FieldConfig<string>
+  to?: FieldConfig<string>
+}) {
+  const [date, setDate] = React.useState<DateRange | undefined>({
+    from:
+      from?.defaultValue && from.defaultValue !== "Invalid Date"
+        ? new Date(from.defaultValue)
+        : new Date(),
+    to:
+      to?.defaultValue && to.defaultValue !== "Invalid Date"
+        ? new Date(to.defaultValue)
+        : addHours(new Date(), 1),
+  })
+
+  const setStartTime = (date: Date | undefined) =>
+    setDate(prev => {
+      if (!date) return prev
+      if (!prev?.to) {
+        return {
+          from: date,
+          to: addHours(date, 1),
+        }
+      } else if (prev?.to > date) {
+        return {
+          ...prev,
+          from: date,
+        }
+      } else {
+        return {
+          from: date,
+          to: addHours(date, 1),
+        }
+      }
+    })
+
+  const setEndTime = (date: Date | undefined) =>
+    setDate(prev => {
+      if (!prev) return prev
+      if (!date) return prev
+      if (!prev?.from) {
+        return {
+          ...prev,
+          to: date,
+        }
+      } else if (date > prev.from) {
+        return {
+          ...prev,
+          to: date,
+        }
+      } else {
+        return prev
+      }
+    })
+
+  const setRange = (date: DateRange | undefined) =>
+    setDate(prev => {
+      if (!date || (!date?.from && !date.to)) {
+        return prev
+      } else if (!date?.to && date.from) {
+        return {
+          ...date,
+          to: addHours(new Date(date?.from), 1),
+        }
+      } else {
+        return date
+      }
+    })
+
+  return (
+    <div className={cn("grid gap-2", className)}>
+      <input
+        type="hidden"
+        required={from?.required}
+        name={from?.name}
+        value={String(date?.from)}
+      />
+
+      <input
+        type="hidden"
+        required={to?.required}
+        name={to?.name}
+        value={String(date?.to)}
+      />
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id="date"
+            variant={"outline"}
+            className={cn(
+              "w-full justify-start text-left font-normal",
+              !date && "text-muted-foreground",
+            )}
+          >
+            <Iconify icon="ph:calendar-blank" className="h-5 w-5" />
+            {date?.from ? (
+              date.to ? (
+                <>
+                  {formatDateDMYHS(date.from)} - {formatDateDMYHS(date.to)}
+                </>
+              ) : (
+                formatDateDMYHS(date.from)
+              )
+            ) : (
+              <span>Pick a date</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            initialFocus
+            mode="range"
+            defaultMonth={date?.from}
+            selected={date}
+            onSelect={setRange}
+            numberOfMonths={2}
+          />
+          <div className="grid grid-cols-1 border-t border-border p-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <FormLabel>Start time</FormLabel>
+              <TimePicker setDate={setStartTime} date={date?.from} />
+            </div>
+            <div className="space-y-2">
+              <FormLabel>End time</FormLabel>
+              <TimePicker setDate={setEndTime} date={date?.to} />
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/app/components/ui/time-picker-input.tsx
+++ b/app/components/ui/time-picker-input.tsx
@@ -1,0 +1,114 @@
+import React from "react"
+import { Input } from "~/components/ui/input"
+import { cn } from "~/utils/cn"
+import {
+  getArrowByType,
+  getDateByType,
+  setDateByType,
+  type TimePickerType,
+} from "~/utils/timepicker"
+
+export interface TimePickerInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  picker: TimePickerType
+  date: Date | undefined
+  setDate: (date: Date | undefined) => void
+  onRightFocus?: () => void
+  onLeftFocus?: () => void
+}
+
+const TimePickerInput = React.forwardRef<
+  HTMLInputElement,
+  TimePickerInputProps
+>(
+  (
+    {
+      className,
+      type = "tel",
+      value,
+      id,
+      name,
+      date = new Date(new Date().setHours(0, 0, 0, 0)),
+      setDate,
+      onChange,
+      onKeyDown,
+      picker,
+      onLeftFocus,
+      onRightFocus,
+      ...props
+    },
+    ref,
+  ) => {
+    const [flag, setFlag] = React.useState<boolean>(false)
+
+    /**
+     * allow the user to enter the second digit within 2 seconds
+     * otherwise start again with entering first digit
+     */
+    React.useEffect(() => {
+      if (flag) {
+        const timer = setTimeout(() => {
+          setFlag(false)
+        }, 2000)
+
+        return () => clearTimeout(timer)
+      }
+    }, [flag])
+
+    const calculatedValue = React.useMemo(
+      () => getDateByType(date, picker),
+      [date, picker],
+    )
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Tab") return
+      e.preventDefault()
+      if (e.key === "ArrowRight") onRightFocus?.()
+      if (e.key === "ArrowLeft") onLeftFocus?.()
+      if (["ArrowUp", "ArrowDown"].includes(e.key)) {
+        const step = e.key === "ArrowUp" ? 1 : -1
+        const newValue = getArrowByType(calculatedValue, step, picker)
+        if (flag) setFlag(false)
+        const tempDate = new Date(date)
+        setDate(setDateByType(tempDate, newValue, picker))
+      }
+      if (e.key >= "0" && e.key <= "9") {
+        const newValue = !flag
+          ? "0" + e.key
+          : calculatedValue.slice(1, 2) + e.key
+        if (flag) onRightFocus?.()
+        setFlag(prev => !prev)
+        const tempDate = new Date(date)
+        setDate(setDateByType(tempDate, newValue, picker))
+      }
+    }
+
+    return (
+      <Input
+        ref={ref}
+        id={id || picker}
+        name={name || picker}
+        className={cn(
+          "w-[48px] text-center font-mono text-base tabular-nums caret-transparent focus:bg-accent focus:text-accent-foreground [&::-webkit-inner-spin-button]:appearance-none",
+          className,
+        )}
+        value={value || calculatedValue}
+        onChange={e => {
+          e.preventDefault()
+          onChange?.(e)
+        }}
+        type={type}
+        inputMode="decimal"
+        onKeyDown={e => {
+          onKeyDown?.(e)
+          handleKeyDown(e)
+        }}
+        {...props}
+      />
+    )
+  },
+)
+
+TimePickerInput.displayName = "TimePickerInput"
+
+export { TimePickerInput }

--- a/app/components/ui/time-picker.tsx
+++ b/app/components/ui/time-picker.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import { FormLabel } from "~/components/ui/form"
+import { Iconify } from "~/components/ui/iconify"
+import { TimePickerInput } from "~/components/ui/time-picker-input"
+
+interface TimePickerDemoProps {
+  date: Date | undefined
+  setDate: (date: Date | undefined) => void
+}
+
+export function TimePicker({ date, setDate }: TimePickerDemoProps) {
+  const minuteRef = React.useRef<HTMLInputElement>(null)
+  const hourRef = React.useRef<HTMLInputElement>(null)
+  const secondRef = React.useRef<HTMLInputElement>(null)
+
+  return (
+    <div className="flex items-end gap-2">
+      <div className="grid gap-1 text-center">
+        <FormLabel htmlFor="hours" className="text-xs">
+          Hours
+        </FormLabel>
+        <TimePickerInput
+          picker="hours"
+          date={date}
+          setDate={setDate}
+          ref={hourRef}
+          onRightFocus={() => minuteRef.current?.focus()}
+        />
+      </div>
+      <div className="grid gap-1 text-center">
+        <FormLabel htmlFor="minutes" className="text-xs">
+          Minutes
+        </FormLabel>
+        <TimePickerInput
+          picker="minutes"
+          date={date}
+          setDate={setDate}
+          ref={minuteRef}
+          onLeftFocus={() => hourRef.current?.focus()}
+          onRightFocus={() => secondRef.current?.focus()}
+        />
+      </div>
+      <div className="grid gap-1 text-center">
+        <FormLabel htmlFor="seconds" className="text-xs">
+          Seconds
+        </FormLabel>
+        <TimePickerInput
+          picker="seconds"
+          date={date}
+          setDate={setDate}
+          ref={secondRef}
+          onLeftFocus={() => minuteRef.current?.focus()}
+        />
+      </div>
+      <div className="flex h-10 items-center">
+        <Iconify icon="ph:timer" className="ml-2 h-4 w-4" />
+      </div>
+    </div>
+  )
+}

--- a/app/models/admin-event.server.ts
+++ b/app/models/admin-event.server.ts
@@ -78,7 +78,18 @@ export const modelAdminEvent = {
     mapsUrl,
     mediaId,
     formatId,
-  }: Pick<Event, "id" | "slug" | "title" | "description" | "formatId"> & {
+    dateTimeStart,
+    dateTimeEnd,
+  }: Pick<
+    Event,
+    | "id"
+    | "slug"
+    | "title"
+    | "description"
+    | "formatId"
+    | "dateTimeStart"
+    | "dateTimeEnd"
+  > & {
     content?: Event["content"]
     mediaId?: Event["mediaId"]
     url?: Event["url"]
@@ -127,6 +138,8 @@ export const modelAdminEvent = {
         locationId,
         mediaId,
         formatId,
+        dateTimeStart,
+        dateTimeEnd,
       },
     })
   },

--- a/app/models/admin-event.server.ts
+++ b/app/models/admin-event.server.ts
@@ -57,10 +57,8 @@ export const modelAdminEvent = {
         content,
         statusId: status.id,
         categoryId: eventCategory?.id,
-        // FIXME: Default dates
-        date: new Date(),
-        timeStart: new Date(),
-        timeEnd: new Date(),
+        dateTimeStart: new Date(),
+        dateTimeEnd: new Date(),
       },
       include: {
         status: true,

--- a/app/models/event-media.server.ts
+++ b/app/models/event-media.server.ts
@@ -1,21 +1,18 @@
-import { type EventMedia } from "@prisma/client";
+import { type EventMedia } from "@prisma/client"
 
 import { prisma } from "~/libs/db.server"
 
 export const modelEventMedia = {
-    getAll() {
-        return prisma.eventMedia.findMany()
-    },
+  getAll() {
+    return prisma.eventMedia.findMany()
+  },
 
-    create({
+  create({ symbol, name }: Pick<EventMedia, "symbol" | "name">) {
+    return prisma.eventMedia.create({
+      data: {
         symbol,
-        name
-    }: Pick<EventMedia, "symbol" | "name">) {
-        return prisma.eventMedia.create({
-            data: {
-                symbol,
-                name
-            }
-        })
-    }
+        name,
+      },
+    })
+  },
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -15,7 +15,7 @@ export const loader = async () => {
     prisma.event.findMany({
       where: {
         status: { OR: [{ symbol: "PUBLISHED" }] },
-        date: { gte: new Date() },
+        dateTimeEnd: { gte: new Date() },
       },
       take: 5,
       orderBy: { updatedAt: "desc" },
@@ -24,7 +24,7 @@ export const loader = async () => {
     prisma.event.findMany({
       where: {
         status: { OR: [{ symbol: "PUBLISHED" }, { symbol: "ARCHIVED" }] },
-        date: { lte: new Date() },
+        dateTimeEnd: { lte: new Date() },
       },
       take: 5,
       orderBy: { updatedAt: "desc" },

--- a/app/routes/admin.dashboard.tsx
+++ b/app/routes/admin.dashboard.tsx
@@ -23,18 +23,18 @@ export const meta: MetaFunction = () =>
     description: `Dashboard for administrator`,
   })
 
-  export const loader = async ({ request }: LoaderFunctionArgs) => {
-    const { user } = await requireUser(request)
-    const counts = await prisma.$transaction([modelEvent.count()])
-  
-    const metrics = configAdminDashboard.navItems
-      .filter(item => item.isMetric)
-      .map((item, index) => {
-        return { ...item, count: counts[index] }
-      })
-  
-    return json({ user, metrics })
-  }
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { user } = await requireUser(request)
+  const counts = await prisma.$transaction([modelEvent.count()])
+
+  const metrics = configAdminDashboard.navItems
+    .filter(item => item.isMetric)
+    .map((item, index) => {
+      return { ...item, count: counts[index] }
+    })
+
+  return json({ user, metrics })
+}
 
 export default function AdminDashboardRoute() {
   const { user, metrics } = useLoaderData<typeof loader>()

--- a/app/routes/admin.events.$eventId.tsx
+++ b/app/routes/admin.events.$eventId.tsx
@@ -101,6 +101,8 @@ export default function UserEventsEventIdRoute() {
       mapsUrl,
       mediaId,
       formatId,
+      dateTimeStart,
+      dateTimeEnd,
     },
   ] = useForm<z.infer<typeof schemaEvent>>({
     id: "update-event",
@@ -304,6 +306,8 @@ export default function UserEventsEventIdRoute() {
               mapsUrl={mapsUrl}
               mediaId={mediaId}
               url={url}
+              dateTimeStart={dateTimeStart}
+              dateTimeEnd={dateTimeEnd}
             />
 
             <Separator className="my-4" />

--- a/app/routes/admin.events._index.tsx
+++ b/app/routes/admin.events._index.tsx
@@ -50,7 +50,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       where,
       skip: config.skip,
       take: config.limitParam,
-      orderBy: { date: "desc" },
+      orderBy: { dateTimeStart: "desc" },
       include: {
         status: { select: { symbol: true, name: true } },
         image: { select: { url: true } },

--- a/app/routes/events.$eventSlug.tsx
+++ b/app/routes/events.$eventSlug.tsx
@@ -131,13 +131,16 @@ export default function EventSlugRoute() {
         <div className="space-y-2">
           <p className="flex justify-between gap-4">
             <b className="basis-4/12">Date:</b>
-            <span className="basis-8/12">{formatDateDMY(event.date)}</span>
-          </p>
-
-          <p className="flex justify-between gap-4">
-            <b className="basis-4/12">Time:</b>
             <span className="basis-8/12">
-              {formatTime(event.timeStart)} – {formatTime(event.timeEnd)}
+              <span>{formatDateDMY(event.dateTimeStart)}</span>
+              <br />
+              <span className="text-muted-foreground">
+                {formatTime(event.dateTimeStart)} –{" "}
+                {formatDateDMY(event.dateTimeStart) !==
+                  formatDateDMY(event.dateTimeEnd) &&
+                  formatDateDMY(event.dateTimeEnd)}{" "}
+                {formatTime(event.dateTimeEnd)} WIB
+              </span>
             </span>
           </p>
 

--- a/app/routes/events.$eventSlug.tsx
+++ b/app/routes/events.$eventSlug.tsx
@@ -22,7 +22,12 @@ import { useRootLoaderData } from "~/hooks/use-root-loader-data"
 import { prisma } from "~/libs/db.server"
 import { modelEventStatus } from "~/models/event-status.server"
 import { modelEvent } from "~/models/event.server"
-import { formatDateDMY, formatTime } from "~/utils/datetime"
+import {
+  formatDateDMY,
+  formatPublished,
+  formatPublishedWithTime,
+  formatTime,
+} from "~/utils/datetime"
 import { invariant, invariantResponse } from "~/utils/invariant"
 import { createMeta } from "~/utils/meta"
 import { createSitemap } from "~/utils/sitemap"
@@ -132,14 +137,15 @@ export default function EventSlugRoute() {
           <p className="flex justify-between gap-4">
             <b className="basis-4/12">Date:</b>
             <span className="basis-8/12">
-              <span>{formatDateDMY(event.dateTimeStart)}</span>
+              <span>{formatPublished(event.dateTimeStart)}</span>
               <br />
               <span className="text-muted-foreground">
                 {formatTime(event.dateTimeStart)} –{" "}
-                {formatDateDMY(event.dateTimeStart) !==
-                  formatDateDMY(event.dateTimeEnd) &&
-                  formatDateDMY(event.dateTimeEnd)}{" "}
-                {formatTime(event.dateTimeEnd)} WIB
+                {formatPublished(event.dateTimeStart) !==
+                formatPublished(event.dateTimeEnd)
+                  ? formatPublishedWithTime(event.dateTimeEnd)
+                  : formatTime(event.dateTimeEnd)}{" "}
+                WIB
               </span>
             </span>
           </p>

--- a/app/routes/events.$eventSlug.tsx
+++ b/app/routes/events.$eventSlug.tsx
@@ -135,7 +135,7 @@ export default function EventSlugRoute() {
 
         <div className="space-y-2">
           <p className="flex justify-between gap-4">
-            <b className="basis-4/12">Date:</b>
+            <b className="basis-4/12">Date and Time:</b>
             <span className="basis-8/12">
               <span>{formatPublished(event.dateTimeStart)}</span>
               <br />

--- a/app/schemas/event.ts
+++ b/app/schemas/event.ts
@@ -39,24 +39,29 @@ const dateTimeStart = z.date({ required_error: "Date start is required" })
 
 const dateTimeEnd = z.date({ required_error: "Date end is required" })
 
-export const schemaEvent = z.object({
-  organizerId,
-  id,
-  slug,
-  title,
-  description,
-  content,
-  readingTime,
-  categoryId,
-  label,
-  address,
-  url,
-  mapsUrl,
-  mediaId,
-  formatId,
-  dateTimeEnd,
-  dateTimeStart,
-})
+export const schemaEvent = z
+  .object({
+    organizerId,
+    id,
+    slug,
+    title,
+    description,
+    content,
+    readingTime,
+    categoryId,
+    label,
+    address,
+    url,
+    mapsUrl,
+    mediaId,
+    formatId,
+    dateTimeEnd,
+    dateTimeStart,
+  })
+  .refine(data => data.dateTimeEnd >= data.dateTimeStart, {
+    message: "End date cannot be earlier than start date",
+    path: ["dateTimeEnd"],
+  })
 
 export const schemaEventCategory = z.object({ id, categoryId })
 

--- a/app/schemas/event.ts
+++ b/app/schemas/event.ts
@@ -35,6 +35,10 @@ const mediaId = z.string().optional()
 
 const formatId = z.string({ required_error: "Format is required" })
 
+const dateTimeStart = z.date({ required_error: "Date start is required" })
+
+const dateTimeEnd = z.date({ required_error: "Date end is required" })
+
 export const schemaEvent = z.object({
   organizerId,
   id,
@@ -50,6 +54,8 @@ export const schemaEvent = z.object({
   mapsUrl,
   mediaId,
   formatId,
+  dateTimeEnd,
+  dateTimeStart,
 })
 
 export const schemaEventCategory = z.object({ id, categoryId })

--- a/app/utils/datetime.ts
+++ b/app/utils/datetime.ts
@@ -24,6 +24,10 @@ export function formatDateYMD(date: string | Date | undefined) {
   return dayjs(date).locale("en").format("YYYY-MM-DD")
 }
 
+export function formatDateDMYHS(date: string | Date | undefined) {
+  return dayjs(date).locale("en").format("D MMMM YYYY HH:ss")
+}
+
 export function formatPublished(date: string | Date | undefined) {
   return dayjs(date).locale("en").format("MMMM D, YYYY")
 }

--- a/app/utils/datetime.ts
+++ b/app/utils/datetime.ts
@@ -32,6 +32,10 @@ export function formatPublished(date: string | Date | undefined) {
   return dayjs(date).locale("en").format("MMMM D, YYYY")
 }
 
+export function formatPublishedWithTime(date: string | Date | undefined) {
+  return dayjs(date).locale("en").format("MMMM D, YYYY, HH:ss ")
+}
+
 /**
  * Time
  */

--- a/app/utils/timepicker.ts
+++ b/app/utils/timepicker.ts
@@ -1,0 +1,146 @@
+/**
+ * regular expression to check for valid hour format (01-23)
+ */
+export function isValidHour(value: string) {
+  return /^(0[0-9]|1[0-9]|2[0-3])$/.test(value)
+}
+
+/**
+ * regular expression to check for valid 12 hour format (01-12)
+ */
+export function isValid12Hour(value: string) {
+  return /^(0[1-9]|1[0-2])$/.test(value)
+}
+
+/**
+ * regular expression to check for valid minute format (00-59)
+ */
+export function isValidMinuteOrSecond(value: string) {
+  return /^[0-5][0-9]$/.test(value)
+}
+
+type GetValidNumberConfig = { max: number; min?: number; loop?: boolean }
+
+export function getValidNumber(
+  value: string,
+  { max, min = 0, loop = false }: GetValidNumberConfig,
+) {
+  let numericValue = parseInt(value, 10)
+
+  if (!isNaN(numericValue)) {
+    if (!loop) {
+      if (numericValue > max) numericValue = max
+      if (numericValue < min) numericValue = min
+    } else {
+      if (numericValue > max) numericValue = min
+      if (numericValue < min) numericValue = max
+    }
+    return numericValue.toString().padStart(2, "0")
+  }
+
+  return "00"
+}
+
+export function getValidHour(value: string) {
+  if (isValidHour(value)) return value
+  return getValidNumber(value, { max: 23 })
+}
+
+export function getValid12Hour(value: string) {
+  if (isValid12Hour(value)) return value
+  return getValidNumber(value, { max: 12 })
+}
+
+export function getValidMinuteOrSecond(value: string) {
+  if (isValidMinuteOrSecond(value)) return value
+  return getValidNumber(value, { max: 59 })
+}
+
+type GetValidArrowNumberConfig = {
+  min: number
+  max: number
+  step: number
+}
+
+export function getValidArrowNumber(
+  value: string,
+  { min, max, step }: GetValidArrowNumberConfig,
+) {
+  let numericValue = parseInt(value, 10)
+  if (!isNaN(numericValue)) {
+    numericValue += step
+    return getValidNumber(String(numericValue), { min, max, loop: true })
+  }
+  return "00"
+}
+
+export function getValidArrowHour(value: string, step: number) {
+  return getValidArrowNumber(value, { min: 0, max: 23, step })
+}
+
+export function getValidArrowMinuteOrSecond(value: string, step: number) {
+  return getValidArrowNumber(value, { min: 0, max: 59, step })
+}
+
+export function setMinutes(date: Date, value: string) {
+  const minutes = getValidMinuteOrSecond(value)
+  date.setMinutes(parseInt(minutes, 10))
+  return date
+}
+
+export function setSeconds(date: Date, value: string) {
+  const seconds = getValidMinuteOrSecond(value)
+  date.setSeconds(parseInt(seconds, 10))
+  return date
+}
+
+export function setHours(date: Date, value: string) {
+  const hours = getValidHour(value)
+  date.setHours(parseInt(hours, 10))
+  return date
+}
+
+export type TimePickerType = "minutes" | "seconds" | "hours" // | "12hours";
+
+export function setDateByType(date: Date, value: string, type: TimePickerType) {
+  switch (type) {
+    case "minutes":
+      return setMinutes(date, value)
+    case "seconds":
+      return setSeconds(date, value)
+    case "hours":
+      return setHours(date, value)
+    default:
+      return date
+  }
+}
+
+export function getDateByType(date: Date, type: TimePickerType) {
+  switch (type) {
+    case "minutes":
+      return getValidMinuteOrSecond(String(date.getMinutes()))
+    case "seconds":
+      return getValidMinuteOrSecond(String(date.getSeconds()))
+    case "hours":
+      return getValidHour(String(date.getHours()))
+    default:
+      return "00"
+  }
+}
+
+export function getArrowByType(
+  value: string,
+  step: number,
+  type: TimePickerType,
+) {
+  switch (type) {
+    case "minutes":
+      return getValidArrowMinuteOrSecond(value, step)
+    case "seconds":
+      return getValidArrowMinuteOrSecond(value, step)
+    case "hours":
+      return getValidArrowHour(value, step)
+    default:
+      return "00"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "cmdk": "^0.2.0",
+    "date-fns": "^3.0.6",
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "html-react-parser": "^5.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ dependencies:
   cmdk:
     specifier: ^0.2.0
     version: 0.2.0(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
+  date-fns:
+    specifier: ^3.0.6
+    version: 3.0.6
   dayjs:
     specifier: ^1.11.10
     version: 1.11.10
@@ -190,7 +193,7 @@ dependencies:
     version: 18.2.0
   react-day-picker:
     specifier: ^8.10.0
-    version: 8.10.0(date-fns@2.30.0)(react@18.2.0)
+    version: 8.10.0(date-fns@3.0.6)(react@18.2.0)
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
@@ -5570,11 +5573,8 @@ packages:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
     engines: {node: '>= 6'}
 
-  /date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-    dependencies:
-      '@babel/runtime': 7.23.5
+  /date-fns@3.0.6:
+    resolution: {integrity: sha512-W+G99rycpKMMF2/YD064b2lE7jJGUe+EjOES7Q8BIGY8sbNdbgcs9XFTZwvzc9Jx1f3k7LB7gZaZa7f8Agzljg==}
     dev: false
 
   /dayjs@1.11.10:
@@ -10525,13 +10525,13 @@ packages:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  /react-day-picker@8.10.0(date-fns@2.30.0)(react@18.2.0):
+  /react-day-picker@8.10.0(date-fns@3.0.6)(react@18.2.0):
     resolution: {integrity: sha512-mz+qeyrOM7++1NCb1ARXmkjMkzWVh2GL9YiPbRjKe0zHccvekk4HE+0MPOZOrosn8r8zTHIIeOUXTmXRqmkRmg==}
     peerDependencies:
       date-fns: ^2.28.0 || ^3.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      date-fns: 2.30.0
+      date-fns: 3.0.6
       react: 18.2.0
     dev: false
 

--- a/prisma/data/events.ts
+++ b/prisma/data/events.ts
@@ -3,9 +3,8 @@ export const dataEvents = [
     slug: "launch",
     title: "Official Setup/Launch",
     description: "BandungDev is being launched to the public.",
-    date: new Date("2023-10-22"),
-    timeStart: new Date("2023-10-22 13:00"),
-    timeEnd: new Date("2023-10-22 18:00"),
+    dateTimeStart: new Date("2023-10-22 13:00"),
+    dateTimeEnd: new Date("2023-10-22 18:00"),
     statusSymbol: "PUBLISHED",
     // categorySymbol: "MEETING",
     content: "BandungDev is being launched to the public.",
@@ -15,9 +14,8 @@ export const dataEvents = [
     title: "Casual Meetup on November 2023",
     description:
       "One of the first meetup for casual introduction, coffee and tea, dicuss various things.",
-    date: new Date("2023-11-11"),
-    timeStart: new Date("2023-11-11 13:00"),
-    timeEnd: new Date("2023-11-11 16:00"),
+    dateTimeStart: new Date("2023-11-11 13:00"),
+    dateTimeEnd: new Date("2023-11-11 16:00"),
     statusSymbol: "PUBLISHED",
     // categorySymbol: "MEETUP",
     content:
@@ -28,9 +26,8 @@ export const dataEvents = [
     title: "Casual Meetup: South on December 2023",
     description:
       "In the south area, casual for introduction, coffee and tea, dicuss various things.",
-    date: new Date("2023-12-30"),
-    timeStart: new Date("2023-12-30 13:00"),
-    timeEnd: new Date("2023-12-30 16:00"),
+    dateTimeStart: new Date("2023-12-30 13:00"),
+    dateTimeEnd: new Date("2023-12-30 16:00"),
     statusSymbol: "PUBLISHED",
     // categorySymbol: "MEETUP",
     content:
@@ -41,9 +38,8 @@ export const dataEvents = [
     title: "Casual Meetup: North on December 2023",
     description:
       "In the north area, casual for introduction, coffee and tea, dicuss various things.",
-    date: new Date("2023-12-30"),
-    timeStart: new Date("2023-12-30 10:00"),
-    timeEnd: new Date("2023-12-30 13:00"),
+    dateTimeStart: new Date("2023-12-30 10:00"),
+    dateTimeEnd: new Date("2023-12-30 13:00"),
     statusSymbol: "PUBLISHED",
     // categorySymbol: "MEETUP",
     content:
@@ -53,9 +49,8 @@ export const dataEvents = [
     slug: "2024-02-18",
     title: "Tech Community Meetup on February 2024",
     description: "The description of the event.",
-    date: new Date("2024-02-18"),
-    timeStart: new Date("2024-02-18 13:00"),
-    timeEnd: new Date("2024-02-18 16:00"),
+    dateTimeStart: new Date("2024-02-18 13:00"),
+    dateTimeEnd: new Date("2024-02-18 16:00"),
     statusSymbol: "DRAFT",
     // categorySymbol: "SEMINAR",
     content:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -239,9 +239,8 @@ model Event {
   content     String? @db.Text // Rich HTML Text
   url         String? // Url for online or hybrid
 
-  date      DateTime @db.Date
-  timeStart DateTime @db.Time()
-  timeEnd   DateTime @db.Time()
+  dateTimeStart DateTime @db.DateTime()
+  dateTimeEnd   DateTime @db.DateTime()
 
   statusId String
   status   EventStatus @relation(fields: [statusId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -239,8 +239,12 @@ model Event {
   content     String? @db.Text // Rich HTML Text
   url         String? // Url for online or hybrid
 
-  dateTimeStart DateTime @db.DateTime()
-  dateTimeEnd   DateTime @db.DateTime()
+  date      DateTime? @db.Date
+  timeStart DateTime? @db.Time()
+  timeEnd   DateTime? @db.Time()
+
+  dateTimeStart DateTime @default(now())
+  dateTimeEnd   DateTime @default(now())
 
   statusId String
   status   EventStatus @relation(fields: [statusId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -239,10 +239,6 @@ model Event {
   content     String? @db.Text // Rich HTML Text
   url         String? // Url for online or hybrid
 
-  date      DateTime? @db.Date
-  timeStart DateTime? @db.Time()
-  timeEnd   DateTime? @db.Time()
-
   dateTimeStart DateTime @default(now())
   dateTimeEnd   DateTime @default(now())
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement feature create and update event to date date time picker field to set date time start and end of the event
- [x] Update schema event from date, timeStart and timeEnd to dateTimeStart and dateTimeEnd
- [x] Add date time start and date time end field
- [x] Show date time start and date time end data on event list and event detail page

## What is the current behavior?

Currnet behavior is event form don't have date and time field, so user can't set date and time for the event, existing feature date is generate by date now and the time is generate to 00:00
<img width="1439" alt="Screen Shot 2024-01-01 at 08 48 32" src="https://github.com/bandungdevcom/bandungdev.com/assets/26239542/7cdda82d-ca8a-4e80-87d4-f9e9b665b7ee">

## What is the new behavior?

- New behavior form event with date time range field
<img width="1433" alt="Screen Shot 2024-01-02 at 17 36 20" src="https://github.com/bandungdevcom/bandungdev.com/assets/26239542/c11c522e-e994-4217-9815-e48211836fe0">


- Adjustment UI event date time 
<img width="1438" alt="Screen Shot 2024-01-02 at 17 35 09" src="https://github.com/bandungdevcom/bandungdev.com/assets/26239542/4ae2233c-5f2e-4708-9c3d-24b5443197a5">
<img width="1431" alt="Screen Shot 2024-01-02 at 17 36 36" src="https://github.com/bandungdevcom/bandungdev.com/assets/26239542/96a38a21-61a6-45c8-8559-f6006d729cf7">


## Additional context

- For date time range picker I created custom component with a reference from https://time.openstatus.dev/ and  date range picker from shadcn/ui
- For UI event date time is reference from https://lu.ma/
<img width="823" alt="Screen Shot 2024-01-02 at 10 20 08" src="https://github.com/bandungdevcom/bandungdev.com/assets/26239542/6503f978-37e0-4b8b-bbe4-d865124081c4">

Related to Close #31 
