### PR TITLE
Adjust & Remove unecessary `as any` usage.

### DIFF
--- a/app/components/contents/team.tsx
+++ b/app/components/contents/team.tsx
@@ -3,15 +3,16 @@ import { Link } from "@remix-run/react"
 import { AvatarAuto } from "~/components/ui/avatar-auto"
 import { Card } from "~/components/ui/card"
 import { type modelUser } from "~/models/user.server"
+import { type JsonifyValues } from "~/types/jsonify"
 import { cn } from "~/utils/cn"
 
 interface ContentTeamProps {
   title: string
-  users: Prisma.PromiseReturnType<typeof modelUser.getAllByTag>
+  users: JsonifyValues<Prisma.PromiseReturnType<typeof modelUser.getAllByTag>>
 }
 
 interface UserCardProps {
-  user: Prisma.PromiseReturnType<typeof modelUser.getByUsername>
+  user: JsonifyValues<Prisma.PromiseReturnType<typeof modelUser.getByUsername>>
 }
 
 export function ContentTeam({ title, users }: ContentTeamProps) {

--- a/app/components/shared/event-item-action.tsx
+++ b/app/components/shared/event-item-action.tsx
@@ -5,14 +5,18 @@ import { FormDelete } from "~/components/shared/form-delete"
 import { ButtonLink } from "~/components/ui/button-link"
 import { Iconify } from "~/components/ui/iconify"
 import { useAppAdminLoaderData } from "~/hooks/use-app-loader-data"
-import { type modelEvent } from "~/models/event.server"
 import { cn } from "~/utils/cn"
 import { truncateText } from "~/utils/string"
+
+import { type modelEvent } from "~/models/event.server"
+import { type JsonifyValues } from "~/types/jsonify"
 
 export function EventItemAction({
   event,
 }: {
-  event: Prisma.PromiseReturnType<typeof modelEvent.getWithStatus>
+  event: JsonifyValues<
+    Prisma.PromiseReturnType<typeof modelEvent.getWithStatus>
+  >
 }) {
   const { eventStatuses } = useAppAdminLoaderData()
   if (!event) return null

--- a/app/components/shared/event-item.tsx
+++ b/app/components/shared/event-item.tsx
@@ -10,7 +10,7 @@ export interface Event {
   date: string
   image: {
     url: string
-  }
+  } | null
 }
 
 export function EventItem({ event }: { event: Event }) {

--- a/app/components/shared/form-change-status.tsx
+++ b/app/components/shared/form-change-status.tsx
@@ -25,6 +25,7 @@ import {
 } from "~/components/ui/select"
 import { type modelEvent } from "~/models/event.server"
 import { type modelPost } from "~/models/post.server"
+import { type JsonifyValues } from "~/types/jsonify"
 import { cn } from "~/utils/cn"
 
 export function FormChangeStatus({
@@ -45,8 +46,8 @@ export function FormChangeStatus({
   // IDEA: Make it more general with a model Item that has a Status
   itemStatuses: PostStatus[] | EventStatus[]
   item:
-    | Prisma.PromiseReturnType<typeof modelPost.getWithStatus>
-    | Prisma.PromiseReturnType<typeof modelEvent.getWithStatus>
+    | JsonifyValues<Prisma.PromiseReturnType<typeof modelPost.getWithStatus>>
+    | JsonifyValues<Prisma.PromiseReturnType<typeof modelEvent.getWithStatus>>
   className?: string
 }) {
   const [open, setOpen] = useState<boolean>()

--- a/app/components/shared/post-item-action.tsx
+++ b/app/components/shared/post-item-action.tsx
@@ -6,13 +6,14 @@ import { ButtonLink } from "~/components/ui/button-link"
 import { Iconify } from "~/components/ui/iconify"
 import { useAppUserLoaderData } from "~/hooks/use-app-loader-data"
 import { type modelPost } from "~/models/post.server"
+import { type JsonifyValues } from "~/types/jsonify"
 import { cn } from "~/utils/cn"
 import { truncateText } from "~/utils/string"
 
 export function PostItemAction({
   post,
 }: {
-  post: Prisma.PromiseReturnType<typeof modelPost.getWithStatus>
+  post: JsonifyValues<Prisma.PromiseReturnType<typeof modelPost.getWithStatus>>
 }) {
   const { postStatuses } = useAppUserLoaderData()
   if (!post) return null

--- a/app/components/shared/post-item.tsx
+++ b/app/components/shared/post-item.tsx
@@ -5,12 +5,13 @@ import { ImageCover } from "~/components/shared/image-cover"
 import { AvatarAuto } from "~/components/ui/avatar-auto"
 import { ButtonLink } from "~/components/ui/button-link"
 import { type modelPost } from "~/models/post.server"
+import { type JsonifyValues } from "~/types/jsonify"
 import { formatPublished } from "~/utils/datetime"
 
 export function PostItem({
   post,
 }: {
-  post: Prisma.PromiseReturnType<typeof modelPost.getBySlug>
+  post: JsonifyValues<Prisma.PromiseReturnType<typeof modelPost.getBySlug>>
 }) {
   if (!post) return null
 

--- a/app/models/admin-event.server.ts
+++ b/app/models/admin-event.server.ts
@@ -21,7 +21,7 @@ export const modelAdminEvent = {
       where: { id },
       include: {
         status: { select: { symbol: true, name: true } },
-        image: { select: { url: true } },
+        image: { select: { url: true, id: true } },
         location: { select: { label: true, address: true, mapsUrl: true } },
       },
     })

--- a/app/models/event-media.server.ts
+++ b/app/models/event-media.server.ts
@@ -1,21 +1,18 @@
-import { type EventMedia } from "@prisma/client";
+import { type EventMedia } from "@prisma/client"
 
 import { prisma } from "~/libs/db.server"
 
 export const modelEventMedia = {
-    getAll() {
-        return prisma.eventMedia.findMany()
-    },
+  getAll() {
+    return prisma.eventMedia.findMany()
+  },
 
-    create({
+  create({ symbol, name }: Pick<EventMedia, "symbol" | "name">) {
+    return prisma.eventMedia.create({
+      data: {
         symbol,
-        name
-    }: Pick<EventMedia, "symbol" | "name">) {
-        return prisma.eventMedia.create({
-            data: {
-                symbol,
-                name
-            }
-        })
-    }
+        name,
+      },
+    })
+  },
 }

--- a/app/models/event.server.ts
+++ b/app/models/event.server.ts
@@ -63,7 +63,7 @@ export const modelEvent = {
       },
       include: {
         status: { select: { symbol: true, name: true } },
-        image: { select: { url: true } },
+        image: { select: { url: true, id: true } },
         format: { select: { symbol: true, name: true } },
         location: { select: { label: true, address: true, mapsUrl: true } },
         category: { select: { symbol: true, name: true } },

--- a/app/models/post.server.ts
+++ b/app/models/post.server.ts
@@ -64,7 +64,7 @@ export const modelPost = {
       },
       include: {
         status: { select: { symbol: true, name: true } },
-        images: { select: { url: true } },
+        images: { select: { url: true, id: true } },
         user: {
           include: {
             images: { select: { url: true } },

--- a/app/models/user-post.server.ts
+++ b/app/models/user-post.server.ts
@@ -25,7 +25,7 @@ export const modelUserPost = {
       where: { id, userId },
       include: {
         status: { select: { symbol: true, name: true } },
-        images: { select: { url: true } },
+        images: { select: { url: true, id: true } },
       },
     })
   },

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -64,7 +64,7 @@ export default function IndexRoute() {
 
       <section className="site-section max-w-4xl">
         <ContentEvents
-          events={upcomingEvents as any}
+          events={upcomingEvents}
           title="Upcoming Events"
           subtitle="See our upcoming events and join us!"
           emptyText="There are no upcoming events again yet"
@@ -73,7 +73,7 @@ export default function IndexRoute() {
 
       <section className="site-section max-w-4xl">
         <ContentEvents
-          events={pastEvents as any}
+          events={pastEvents}
           title="Past Events"
           subtitle="Some of the finished events"
           emptyText="There are no past events"
@@ -85,7 +85,7 @@ export default function IndexRoute() {
         <ContentMembers
           title="Newly Joined Community Members"
           subtitle="Join our community and meet other developers in Bandung"
-          users={users as any}
+          users={users}
           withSeeMore
         />
       </section>

--- a/app/routes/_page.about.tsx
+++ b/app/routes/_page.about.tsx
@@ -27,7 +27,7 @@ export default function AboutRoute() {
       </section>
 
       <section>
-        <ContentTeam title="Our Team" users={teamUsers as any} />
+        <ContentTeam title="Our Team" users={teamUsers} />
       </section>
     </div>
   )

--- a/app/routes/admin.dashboard.tsx
+++ b/app/routes/admin.dashboard.tsx
@@ -23,18 +23,18 @@ export const meta: MetaFunction = () =>
     description: `Dashboard for administrator`,
   })
 
-  export const loader = async ({ request }: LoaderFunctionArgs) => {
-    const { user } = await requireUser(request)
-    const counts = await prisma.$transaction([modelEvent.count()])
-  
-    const metrics = configAdminDashboard.navItems
-      .filter(item => item.isMetric)
-      .map((item, index) => {
-        return { ...item, count: counts[index] }
-      })
-  
-    return json({ user, metrics })
-  }
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { user } = await requireUser(request)
+  const counts = await prisma.$transaction([modelEvent.count()])
+
+  const metrics = configAdminDashboard.navItems
+    .filter(item => item.isMetric)
+    .map((item, index) => {
+      return { ...item, count: counts[index] }
+    })
+
+  return json({ user, metrics })
+}
 
 export default function AdminDashboardRoute() {
   const { user, metrics } = useLoaderData<typeof loader>()

--- a/app/routes/admin.events.$eventId.tsx
+++ b/app/routes/admin.events.$eventId.tsx
@@ -225,7 +225,7 @@ export default function UserEventsEventIdRoute() {
                   dialogTitle="Change event's status"
                   dialogDescription={`Change the status of event: ${event.title} (${event.slug})`}
                   itemStatuses={eventStatuses}
-                  item={event as any}
+                  item={event}
                 />
               </div>
             </div>

--- a/app/routes/admin.events._index.tsx
+++ b/app/routes/admin.events._index.tsx
@@ -53,7 +53,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       orderBy: { date: "desc" },
       include: {
         status: { select: { symbol: true, name: true } },
-        image: { select: { url: true } },
+        image: { select: { url: true, id: true } },
       },
     }),
   ])
@@ -104,7 +104,7 @@ export default function UserEventsRoute() {
         {events.length > 0 && (
           <ul className="divide-y">
             {events.map(event => (
-              <EventItemAction key={event.id} event={event as any} />
+              <EventItemAction key={event.id} event={event} />
             ))}
           </ul>
         )}

--- a/app/routes/events.$eventSlug.tsx
+++ b/app/routes/events.$eventSlug.tsx
@@ -96,7 +96,7 @@ export default function EventSlugRoute() {
                 dialogTitle="Change event's status"
                 dialogDescription={`Change the status of event: ${event.title} (${event.slug})`}
                 itemStatuses={eventStatuses}
-                item={event as any}
+                item={event}
               />
               <ButtonLink
                 to={`/admin/events/${event.id}`}

--- a/app/routes/events._index.tsx
+++ b/app/routes/events._index.tsx
@@ -92,7 +92,7 @@ export default function SearchRoute() {
         <ul className="space-y-12">
           {events.map(event => (
             <li key={event.id}>
-              <EventItem event={event as any} />
+              <EventItem event={event} />
             </li>
           ))}
         </ul>

--- a/app/routes/members._index.tsx
+++ b/app/routes/members._index.tsx
@@ -82,7 +82,7 @@ export default function MembersRoute() {
         <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
           {users.map(user => (
             <li key={user.id}>
-              <UserItem user={user as any} />
+              <UserItem user={user} />
             </li>
           ))}
         </ul>

--- a/app/routes/posts.$postSlug.tsx
+++ b/app/routes/posts.$postSlug.tsx
@@ -122,8 +122,9 @@ export default function PostSlugRoute() {
               dialogTitle="Change post's status"
               dialogDescription={`Change the status of post: ${post.title} (${post.slug})`}
               itemStatuses={postStatuses}
-              item={post as any}
+              item={post}
             />
+
             <ButtonLink
               to={`/user/posts/${post.id}`}
               variant="outline"

--- a/app/routes/posts._index.tsx
+++ b/app/routes/posts._index.tsx
@@ -58,6 +58,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       include: {
         images: { select: { id: true, url: true } },
         user: { include: { images: { select: { id: true, url: true } } } },
+        status: { select: { symbol: true, name: true } },
       },
     }),
   ])
@@ -93,7 +94,7 @@ export default function SearchRoute() {
         <ul className="space-y-12">
           {posts.map(post => (
             <li key={post.id}>
-              <PostItem post={post as any} />
+              <PostItem post={post} />
             </li>
           ))}
         </ul>

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -64,8 +64,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       take: config.limitParam,
       orderBy: { updatedAt: "desc" },
       include: {
-        images: { select: { url: true } },
+        images: { select: { url: true, id: true } },
         user: { include: { images: { select: { id: true, url: true } } } },
+        status: { select: { symbol: true, name: true } },
       },
     }),
   ])
@@ -102,7 +103,7 @@ export default function SearchRoute() {
         <ul className="space-y-12">
           {posts.map(post => (
             <li key={post.id}>
-              <PostItem post={post as any} />
+              <PostItem post={post} />
             </li>
           ))}
         </ul>

--- a/app/routes/user.posts.$postId.tsx
+++ b/app/routes/user.posts.$postId.tsx
@@ -185,7 +185,7 @@ export default function UserPostsPostIdRoute() {
                   dialogTitle="Change post's status"
                   dialogDescription={`Change the status of post: ${post.title} (${post.slug})`}
                   itemStatuses={postStatuses}
-                  item={post as any}
+                  item={post}
                 />
               </div>
             </div>

--- a/app/routes/user.posts._index.tsx
+++ b/app/routes/user.posts._index.tsx
@@ -54,7 +54,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       orderBy: { updatedAt: "desc" },
       include: {
         status: { select: { symbol: true, name: true } },
-        images: { select: { url: true } },
+        images: { select: { url: true, id: true } },
       },
     }),
   ])
@@ -105,7 +105,7 @@ export default function UserPostsRoute() {
         {posts.length > 0 && (
           <ul className="divide-y">
             {posts.map(post => (
-              <PostItemAction key={post.id} post={post as any} />
+              <PostItemAction key={post.id} post={post} />
             ))}
           </ul>
         )}

--- a/app/types/jsonify.ts
+++ b/app/types/jsonify.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line import/consistent-type-specifier-style
+import type { Jsonify } from "node_modules/.pnpm/@remix-run+server-runtime@2.4.1_typescript@5.3.3/node_modules/@remix-run/server-runtime/dist/jsonify.d.ts"
+
+export type JsonifyValues<T> = {
+  [K in keyof T]: Jsonify<T[K]>
+}


### PR DESCRIPTION
## What is the new behavior?
Most of the `as any` have been removed.

## Additional Context
The returned type from `json()` in the loader is turning data coming from db into json type. It means some type like `Date` is converted into `string`. To tackle this, I create a utility type `JsonifyValues` to convert type from prisma into the exact type returned from the `loader`. The type is basically coming inside `node_modules` I just copy and paste it.

I also adjust some query inside `models` & `transactions` to match the type coming from some component like `EventItem`, `UserItem`, etc.