### PR TITLE
Modify db query to user upsert

### DIFF
--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -241,16 +241,28 @@ export const modelUser = {
   },
 
   updateHeadline({ id, headline }: Pick<UserProfile, "id" | "headline">) {
-    return prisma.user.update({
-      where: { id },
-      data: { profile: { update: { headline } } },
+    return prisma.userProfile.upsert({
+      where: { userId: id },
+      update: {
+        headline,
+      },
+      create: {
+        userId: id,
+        headline,
+      },
     })
   },
 
   updateBio({ id, bio }: Pick<UserProfile, "id" | "bio">) {
-    return prisma.user.update({
-      where: { id },
-      data: { profile: { update: { bio } } },
+    return prisma.userProfile.upsert({
+      where: { userId: id },
+      update: {
+        bio,
+      },
+      create: {
+        userId: id,
+        bio,
+      },
     })
   },
 
@@ -260,9 +272,15 @@ export const modelUser = {
   }: Pick<UserProfile, "id"> & {
     links?: JsonLinks
   }) {
-    return prisma.user.update({
-      where: { id },
-      data: { profile: { update: { links: links ?? [] } } },
+    return prisma.userProfile.upsert({
+      where: { userId: id },
+      update: {
+        links: links ?? [],
+      },
+      create: {
+        userId: id,
+        links: links ?? [],
+      },
     })
   },
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix user settings when changing headline, bio

## What is the current behavior?

https://github.com/bandungdevcom/bandungdev.com/issues/48

Using upsert because when user first time registered, they dont have `profile` yet. If user doesn't have profile, create it. Otherwise just update existing profile.

