### PR TITLE
Event price rield

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -260,6 +260,8 @@ model Event {
   imageId String?
   image   EventImage? @relation(fields: [imageId], references: [id])
 
+  tickets Ticket[]
+
   organizerId String
   organizer   User   @relation("EventOrganizer", fields: [organizerId], references: [id])
   applicants  User[] @relation("EventApplicant")
@@ -362,6 +364,26 @@ model Location {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+// -----------------------------------------------------------------------------
+// Ticket
+// -----------------------------------------------------------------------------
+
+model Ticket {
+  id String @id @default(cuid())
+
+  name        String // name of ticket like student ticket, general ticket, full ticket etc
+  price       Int
+  description String? @db.Text // the description about the ticket like this ticket include zoom record
+
+  eventId String?
+  event   Event?  @relation(fields: [eventId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([eventId])
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement to add event price field

## What is the current behavior?

The current behavior is on event page don't have information about the event is free or paid, and if paid how much is the ticket
<img width="1437" alt="Screen Shot 2024-01-09 at 06 50 24" src="https://github.com/bandungdevcom/bandungdev.com/assets/26239542/3bf1bacb-7b89-4ecc-b12f-0a2293b2fe45">

The current behavior don't have price or ticket field
<img width="1439" alt="Screen Shot 2024-01-09 at 06 51 31" src="https://github.com/bandungdevcom/bandungdev.com/assets/26239542/7a4be18d-8898-4f64-925b-a775c7d5ea8f">

&nbsp;
&nbsp;
Related to Close #50 