### PR TITLE
fix event location url display

### DIFF
--- a/app/routes/events.$eventSlug.tsx
+++ b/app/routes/events.$eventSlug.tsx
@@ -133,8 +133,8 @@ export default function EventSlugRoute() {
         <h1>{event.title}</h1>
         <h2 className="text-xl">{event.description}</h2>
 
-        <div className="space-y-2">
-          <p className="flex flex-col justify-between md:flex-row md:gap-4">
+        <div className="space-y-4 md:space-y-2">
+          <p className="flex flex-col justify-between gap-1 md:flex-row md:gap-4">
             <b className="md:basis-4/12">Date and Time:</b>
             <span className="md:basis-8/12">
               <span>{formatPublished(event.dateTimeStart)}</span>
@@ -151,14 +151,14 @@ export default function EventSlugRoute() {
           </p>
 
           {event.format?.name && (
-            <p className="flex flex-col justify-between md:flex-row md:gap-4">
+            <p className="flex flex-col justify-between gap-1 md:flex-row md:gap-4">
               <b className="md:md:basis-4/12">Format:</b>
               <span className="md:md:basis-8/12">{event.format?.name} </span>
             </p>
           )}
 
           {event.category?.name && (
-            <p className="flex flex-col justify-between md:flex-row md:gap-4">
+            <p className="flex flex-col justify-between gap-1 md:flex-row md:gap-4">
               <b className="md:basis-4/12">Category:</b>
               <span className="md:basis-8/12">{event.category?.name} </span>
             </p>
@@ -168,7 +168,7 @@ export default function EventSlugRoute() {
             (event.location?.address ||
               event.location?.label ||
               event.location?.mapsUrl) && (
-              <p className="flex flex-col justify-between md:flex-row md:gap-4">
+              <p className="flex flex-col justify-between gap-1 md:flex-row md:gap-4">
                 <b className="md:basis-4/12">
                   <span>Location</span>
                   {isHybrid && <span> (In Person)</span>}
@@ -211,7 +211,7 @@ export default function EventSlugRoute() {
             )}
 
           {(isOnline || isHybrid) && event.url && event.media && (
-            <p className="flex flex-col justify-between md:flex-row md:gap-4">
+            <p className="flex flex-col justify-between gap-1 md:flex-row md:gap-4">
               <b className="basis-4/12">
                 <span>Location</span>
                 {isHybrid && <span> (Online)</span>}

--- a/app/routes/events.$eventSlug.tsx
+++ b/app/routes/events.$eventSlug.tsx
@@ -134,9 +134,9 @@ export default function EventSlugRoute() {
         <h2 className="text-xl">{event.description}</h2>
 
         <div className="space-y-2">
-          <p className="flex justify-between gap-4">
-            <b className="basis-4/12">Date and Time:</b>
-            <span className="basis-8/12">
+          <p className="flex flex-col justify-between md:flex-row md:gap-4">
+            <b className="md:basis-4/12">Date and Time:</b>
+            <span className="md:basis-8/12">
               <span>{formatPublished(event.dateTimeStart)}</span>
               <br />
               <span className="text-muted-foreground">
@@ -151,16 +151,16 @@ export default function EventSlugRoute() {
           </p>
 
           {event.format?.name && (
-            <p className="flex justify-between gap-4">
-              <b className="basis-4/12">Format:</b>
-              <span className="basis-8/12">{event.format?.name} </span>
+            <p className="flex flex-col justify-between md:flex-row md:gap-4">
+              <b className="md:md:basis-4/12">Format:</b>
+              <span className="md:md:basis-8/12">{event.format?.name} </span>
             </p>
           )}
 
           {event.category?.name && (
-            <p className="flex justify-between gap-4">
-              <b className="basis-4/12">Category:</b>
-              <span className="basis-8/12">{event.category?.name} </span>
+            <p className="flex flex-col justify-between md:flex-row md:gap-4">
+              <b className="md:basis-4/12">Category:</b>
+              <span className="md:basis-8/12">{event.category?.name} </span>
             </p>
           )}
 
@@ -168,13 +168,13 @@ export default function EventSlugRoute() {
             (event.location?.address ||
               event.location?.label ||
               event.location?.mapsUrl) && (
-              <p className="flex justify-between gap-4">
-                <b className="basis-4/12">
+              <p className="flex flex-col justify-between md:flex-row md:gap-4">
+                <b className="md:basis-4/12">
                   <span>Location</span>
                   {isHybrid && <span> (In Person)</span>}
                   <span>:</span>
                 </b>
-                <div className="basis-8/12">
+                <div className="md:basis-8/12">
                   {event.location.label && (
                     <Link
                       to={event.location?.mapsUrl || ""}
@@ -211,7 +211,7 @@ export default function EventSlugRoute() {
             )}
 
           {(isOnline || isHybrid) && event.url && event.media && (
-            <p className="flex justify-between gap-4">
+            <p className="flex flex-col justify-between md:flex-row md:gap-4">
               <b className="basis-4/12">
                 <span>Location</span>
                 {isHybrid && <span> (Online)</span>}

--- a/app/routes/events.$eventSlug.tsx
+++ b/app/routes/events.$eventSlug.tsx
@@ -197,7 +197,7 @@ export default function EventSlugRoute() {
                     <Link
                       to={event.location?.mapsUrl || ""}
                       target="_blank"
-                      className="inline-flex gap-1 text-accent"
+                      className="inline-flex gap-1 break-all text-accent"
                     >
                       {event.location?.mapsUrl}
                       <Iconify
@@ -222,7 +222,7 @@ export default function EventSlugRoute() {
                 <Link
                   to={event.url || ""}
                   target="_blank"
-                  className="inline-flex gap-1 text-accent"
+                  className="inline-flex gap-1 break-all text-accent"
                 >
                   {event.url}
                   <Iconify


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix overflow text event location url display

## What is the current behavior?

![current behavior](https://private-user-images.githubusercontent.com/235584/295845665-c3f01fdb-5edf-4813-ac89-881cd566ef29.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDQ5ODM2NDQsIm5iZiI6MTcwNDk4MzM0NCwicGF0aCI6Ii8yMzU1ODQvMjk1ODQ1NjY1LWMzZjAxZmRiLTVlZGYtNDgxMy1hYzg5LTg4MWNkNTY2ZWYyOS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwMTExJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDExMVQxNDI5MDRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0zNjQzNjMzMGMyZjlmZDc5NWI1ZjIwZjY0M2E5ZDAwNDQwZGE4ZTgxMmFjMTNlMDRlZmU0ODI1YTkzOTNhOTE2JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.8sQScnCeqAyga64eaNwy0BKC2a9JrrmCwCM5TB4rqm0)

## What is the new behavior?

<img width="350" alt="Screen Shot 2024-01-11 at 21 48 44" src="https://github.com/bandungdevcom/bandungdev.com/assets/26239542/4dd5ab5f-0815-485e-aa99-6544bbdef3a3">


## Additional context

Related to Close #53 
