### PR TITLE
feat: partners and sponsors

### DIFF
--- a/app/components/contents/about.tsx
+++ b/app/components/contents/about.tsx
@@ -32,11 +32,11 @@ export function ContentAbout() {
         </p>
         <p>
           Based on this idea, BandungDev is being initiated and collaborating
-          with various other tech communities and companies such as WPU (aka Web Programming UNPAS), Programmer
-          Zaman Now (PZN), GDG Bandung (Google
-          Developer Group), JVM Indonesia, Indonesia Belajar, Kelas Terbuka, Android Developer
-          Bandung (ADB), BandungPy, BandungJS, ReactJS Indonesia, Binary
-          Nusantara, Bearmentor, Catamyst, and much more.
+          with various other tech communities and companies such as WPU (aka Web
+          Programming UNPAS), Programmer Zaman Now (PZN), GDG Bandung (Google
+          Developer Group), JVM Indonesia, Indonesia Belajar, Kelas Terbuka,
+          Android Developer Bandung (ADB), BandungPy, BandungJS, ReactJS
+          Indonesia, Binary Nusantara, Bearmentor, Catamyst, and much more.
         </p>
         <p>
           Our committee members are: M Haidar Hanif, Hendi Santika, Kresna

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -43,7 +43,7 @@ const buttonVariants = cva(
   },
 )
 
-interface ButtonProps
+export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean

--- a/app/components/ui/pagination.tsx
+++ b/app/components/ui/pagination.tsx
@@ -1,7 +1,7 @@
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
 import * as React from "react"
 
-import { type ButtonProps, buttonVariants } from "~/components/ui/button"
+import { buttonVariants, type ButtonProps } from "~/components/ui/button"
 import { cn } from "~/utils/cn"
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (

--- a/app/components/ui/pagination.tsx
+++ b/app/components/ui/pagination.tsx
@@ -1,0 +1,117 @@
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+import * as React from "react"
+
+import { type ButtonProps, buttonVariants } from "~/components/ui/button"
+import { cn } from "~/utils/cn"
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn("mx-auto flex w-full justify-center", className)}
+    {...props}
+  />
+)
+Pagination.displayName = "Pagination"
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn("flex flex-row items-center gap-1", className)}
+    {...props}
+  />
+))
+PaginationContent.displayName = "PaginationContent"
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn("", className)} {...props} />
+))
+PaginationItem.displayName = "PaginationItem"
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<ButtonProps, "size"> &
+  React.ComponentProps<"a">
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = "xs",
+  ...props
+}: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? "page" : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? "outline" : "ghost",
+        size,
+      }),
+      className,
+    )}
+    {...props}
+  />
+)
+PaginationLink.displayName = "PaginationLink"
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <ChevronLeft className="h-4 w-4" />
+    <span>Previous</span>
+  </PaginationLink>
+)
+PaginationPrevious.displayName = "PaginationPrevious"
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Next</span>
+    <ChevronRight className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationNext.displayName = "PaginationNext"
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    aria-hidden
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+)
+PaginationEllipsis.displayName = "PaginationEllipsis"
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+}

--- a/app/configs/navigation.ts
+++ b/app/configs/navigation.ts
@@ -132,6 +132,11 @@ export const configNavigationItems: NavItem[] = [
     text: "Notifications",
   },
   {
+    path: "/admin/partners-and-sponsors",
+    icon: "material-symbols:partner-exchange",
+    text: "Patners & Sponsors",
+  },
+  {
     path: "/examples",
     icon: "ph:bounding-box-duotone",
     text: "Examples",

--- a/app/routes/admin.partners-and-sponsors.$id.edit.tsx
+++ b/app/routes/admin.partners-and-sponsors.$id.edit.tsx
@@ -49,16 +49,16 @@ export default function PartnersAndSponsorsEditRoute() {
                   />
                 </div>
                 <div className="flex flex-col space-y-1.5">
-                  <Label htmlFor="partners-or-sponsors">
-                    Partners / Sponsors
+                  <Label htmlFor="partner-or-sponsor">
+                    Community Partner / Sponsor
                   </Label>
-                  <Select defaultValue="partners">
-                    <SelectTrigger id="partners-or-sponsors">
-                      <SelectValue placeholder="Partners / Sponsors" />
+                  <Select>
+                    <SelectTrigger id="partner-or-sponsor">
+                      <SelectValue placeholder="Community Partner / Sponsor" />
                     </SelectTrigger>
                     <SelectContent position="popper">
-                      <SelectItem value="partners">Partners</SelectItem>
-                      <SelectItem value="sponsors">Sponsors</SelectItem>
+                      <SelectItem value="partner">Community Partner</SelectItem>
+                      <SelectItem value="sponsor">Sponsor</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/app/routes/admin.partners-and-sponsors.$id.edit.tsx
+++ b/app/routes/admin.partners-and-sponsors.$id.edit.tsx
@@ -1,0 +1,77 @@
+import { Button } from "~/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card"
+import { Input } from "~/components/ui/input"
+import { Label } from "~/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select"
+
+export default function PartnersAndSponsorsEditRoute() {
+  return (
+    <div className="app-container">
+      <header className="app-header">
+        <div>
+          <h2>Partners and Sponsors</h2>
+        </div>
+      </header>
+      <section className="app-section">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Edit Partners or Sponsors</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form>
+              <div className="grid w-full items-center gap-4">
+                <div className="flex flex-col space-y-1.5">
+                  <Label htmlFor="name">Name</Label>
+                  <Input
+                    id="name"
+                    placeholder="partners or sponsors name"
+                    defaultValue={"Web Programing UNPAS"}
+                  />
+                </div>
+                <div className="flex flex-col space-y-1.5">
+                  <Label htmlFor="name">Link</Label>
+                  <Input
+                    id="name"
+                    placeholder="https://"
+                    defaultValue={"https://youtube.com/c/webprogrammingunpas"}
+                  />
+                </div>
+                <div className="flex flex-col space-y-1.5">
+                  <Label htmlFor="partners-or-sponsors">
+                    Partners / Sponsors
+                  </Label>
+                  <Select defaultValue="partners">
+                    <SelectTrigger id="partners-or-sponsors">
+                      <SelectValue placeholder="Partners / Sponsors" />
+                    </SelectTrigger>
+                    <SelectContent position="popper">
+                      <SelectItem value="partners">Partners</SelectItem>
+                      <SelectItem value="sponsors">Sponsors</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </form>
+          </CardContent>
+          <CardFooter className="flex justify-end gap-2">
+            <Button variant="outline">Cancel</Button>
+            <Button>Edit</Button>
+            <Button variant="destructive">Delete</Button>
+          </CardFooter>
+        </Card>
+      </section>
+    </div>
+  )
+}

--- a/app/routes/admin.partners-and-sponsors._index.tsx
+++ b/app/routes/admin.partners-and-sponsors._index.tsx
@@ -30,11 +30,13 @@ export default function PartnersAndSponsorsRoute() {
 
       <section className="app-section">
         <div className="flex w-full flex-wrap justify-end">
-          <ButtonLink to="/events" variant="outline" size="xs">
+          <ButtonLink
+            to="/admin/partners-and-sponsors/new/"
+            variant="outline"
+            size="xs"
+          >
             <Iconify icon="ph:plus" />
-            <Link to="/admin/partners-and-sponsors/new/">
-              <span>Add Partner or Sponsor</span>
-            </Link>
+            <span>Add Partner or Sponsor</span>
           </ButtonLink>
         </div>
         <Table>

--- a/app/routes/admin.partners-and-sponsors._index.tsx
+++ b/app/routes/admin.partners-and-sponsors._index.tsx
@@ -1,0 +1,130 @@
+import { Link } from "@remix-run/react"
+import { Button } from "~/components/ui/button"
+import { ButtonLink } from "~/components/ui/button-link"
+import { Iconify } from "~/components/ui/iconify"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "~/components/ui/pagination"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table"
+
+export default function PartnersAndSponsorsRoute() {
+  return (
+    <div className="app-container">
+      <header className="app-header">
+        <div>
+          <h2>Partners and Sponsors</h2>
+        </div>
+      </header>
+
+      <section className="app-section">
+        <div className="flex w-full flex-wrap justify-end">
+          <ButtonLink to="/events" variant="outline" size="xs">
+            <Iconify icon="ph:plus" />
+            <Link to="/admin/partners-and-sponsors/new/">
+              <span>Add Partner or Sponsor</span>
+            </Link>
+          </ButtonLink>
+        </div>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Link</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>Web Programing UNPAS</TableCell>
+              <TableCell>https://youtube.com/c/webprogrammingunpas</TableCell>
+              <TableCell>Community Partners</TableCell>
+              <TableCell className="flex gap-2">
+                <Button>
+                  <Link to="/admin/partners-and-sponsors/1/edit/">Edit</Link>
+                </Button>
+                <Button variant="destructive">Delete</Button>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Bearmentor</TableCell>
+              <TableCell>https://bearmentor.com/</TableCell>
+              <TableCell>Community Partners</TableCell>
+              <TableCell className="flex gap-2">
+                <Button>
+                  <Link to="/admin/partners-and-sponsors/1/edit/">Edit</Link>
+                </Button>
+                <Button variant="destructive">Delete</Button>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>CodePolitan</TableCell>
+              <TableCell>https://codepolitan.com/</TableCell>
+              <TableCell>Sponsors</TableCell>
+              <TableCell className="flex gap-2">
+                <Button>
+                  <Link to="/admin/partners-and-sponsors/1/edit/">Edit</Link>
+                </Button>
+                <Button variant="destructive">Delete</Button>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Programmer Zaman Now</TableCell>
+              <TableCell>https://programmerzamannow.com/</TableCell>
+              <TableCell>Community Partners</TableCell>
+              <TableCell className="flex gap-2">
+                <Button>
+                  <Link to="/admin/partners-and-sponsors/1/edit/">Edit</Link>
+                </Button>
+                <Button variant="destructive">Delete</Button>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Allnimal</TableCell>
+              <TableCell>https://allnimal.com/</TableCell>
+              <TableCell>Sponsors</TableCell>
+              <TableCell className="flex gap-2">
+                <Button>
+                  <Link to="/admin/partners-and-sponsors/1/edit/">Edit</Link>
+                </Button>
+                <Button variant="destructive">Delete</Button>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious href="#" size="default" />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href="#" size="default" isActive={true}>
+                1
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href="#" size="default">
+                2
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext href="#" size="default" />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </section>
+    </div>
+  )
+}

--- a/app/routes/admin.partners-and-sponsors.new.tsx
+++ b/app/routes/admin.partners-and-sponsors.new.tsx
@@ -1,0 +1,68 @@
+import { Button } from "~/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card"
+import { Input } from "~/components/ui/input"
+import { Label } from "~/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select"
+
+export default function PartnersAndSponsorsNewRoute() {
+  return (
+    <div className="app-container">
+      <header className="app-header">
+        <div>
+          <h2>Partners and Sponsors</h2>
+        </div>
+      </header>
+      <section className="app-section">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Add Partners or Sponsors</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form>
+              <div className="grid w-full items-center gap-4">
+                <div className="flex flex-col space-y-1.5">
+                  <Label htmlFor="name">Name</Label>
+                  <Input id="name" placeholder="partners or sponsors name" />
+                </div>
+                <div className="flex flex-col space-y-1.5">
+                  <Label htmlFor="name">Link</Label>
+                  <Input id="name" placeholder="https://" />
+                </div>
+                <div className="flex flex-col space-y-1.5">
+                  <Label htmlFor="partners-or-sponsors">
+                    Partners / Sponsors
+                  </Label>
+                  <Select>
+                    <SelectTrigger id="partners-or-sponsors">
+                      <SelectValue placeholder="Partners / Sponsors" />
+                    </SelectTrigger>
+                    <SelectContent position="popper">
+                      <SelectItem value="partners">Partners</SelectItem>
+                      <SelectItem value="sponsors">Sponsors</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </form>
+          </CardContent>
+          <CardFooter className="flex justify-end gap-2">
+            <Button variant="outline">Cancel</Button>
+            <Button>Add</Button>
+          </CardFooter>
+        </Card>
+      </section>
+    </div>
+  )
+}

--- a/app/routes/admin.partners-and-sponsors.new.tsx
+++ b/app/routes/admin.partners-and-sponsors.new.tsx
@@ -41,16 +41,16 @@ export default function PartnersAndSponsorsNewRoute() {
                   <Input id="name" placeholder="https://" />
                 </div>
                 <div className="flex flex-col space-y-1.5">
-                  <Label htmlFor="partners-or-sponsors">
-                    Partners / Sponsors
+                  <Label htmlFor="partner-or-sponsor">
+                    Community Partner / Sponsor
                   </Label>
                   <Select>
-                    <SelectTrigger id="partners-or-sponsors">
-                      <SelectValue placeholder="Partners / Sponsors" />
+                    <SelectTrigger id="partner-or-sponsor">
+                      <SelectValue placeholder="Community Partner / Sponsor" />
                     </SelectTrigger>
                     <SelectContent position="popper">
-                      <SelectItem value="partners">Partners</SelectItem>
-                      <SelectItem value="sponsors">Sponsors</SelectItem>
+                      <SelectItem value="partner">Community Partner</SelectItem>
+                      <SelectItem value="sponsor">Sponsor</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -46,6 +46,7 @@ export default function AdminLayoutRoute() {
     "/admin/events",
     "/admin/posts",
     "/admin/settings",
+    "/admin/partners-and-sponsors",
   ]
 
   return (

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "dotenv": "^16.3.1",
     "html-react-parser": "^5.1.0",
     "isbot": "^4.3.0",
+    "lucide-react": "^0.330.0",
     "nanoid": "^5.0.4",
     "pluralize": "^8.0.0",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ dependencies:
   isbot:
     specifier: ^4.3.0
     version: 4.3.0
+  lucide-react:
+    specifier: ^0.330.0
+    version: 0.330.0(react@18.2.0)
   nanoid:
     specifier: ^5.0.4
     version: 5.0.4
@@ -8225,6 +8228,14 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
     dev: true
+
+  /lucide-react@0.330.0(react@18.2.0):
+    resolution: {integrity: sha512-CQwY+Fpbt2kxCoVhuN0RCZDCYlbYnqB870Bl/vIQf3ER/cnDDQ6moLmEkguRyruAUGd4j3Lc4mtnJosXnqHheA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}


### PR DESCRIPTION
## What kind of change does this PR introduce?

to solve issue #38 

## What is the current behavior?

Landing page would show partners and sponsors using a JSON or TypeScript data file (static).
![sponsors and community partners on landing page](https://github.com/bandungdevcom/bandungdev.com/assets/26587145/33632584-91f7-4cd1-b9f3-2cbe61ed3210)

## What is the new behavior?

Add sponsors and partners management on admin panel and stored data on database (make it dynamic). These are UI for sponsors and partners management:
![sponsors and comunity partners list](https://github.com/bandungdevcom/bandungdev.com/assets/26587145/1d6fb38d-2a7c-40f3-99c8-0735af9aaf86)
![sponsors and comunity partners new](https://github.com/bandungdevcom/bandungdev.com/assets/26587145/c01f609e-ae07-427f-a1db-d3eab894d3df)
![sponsors and comunity edit](https://github.com/bandungdevcom/bandungdev.com/assets/26587145/228e0a68-6976-4d23-83c2-27f70e0bc442)
