### PR TITLE
feat: confirmation pop up before user account deletion

### DIFF
--- a/app/components/shared/form-delete.tsx
+++ b/app/components/shared/form-delete.tsx
@@ -27,6 +27,7 @@ export function FormDelete({
   disabled,
   extraComponent,
   className,
+  customButton,
 }: {
   action: string // Example: /user/posts/delete
   intentValue: string // Example: delete-post-by-id
@@ -39,6 +40,7 @@ export function FormDelete({
   disabled?: boolean
   extraComponent?: React.ReactNode
   className?: string
+  customButton?: React.ReactNode
 }) {
   const [open, setOpen] = useState<boolean>()
   const location = useLocation()
@@ -49,10 +51,10 @@ export function FormDelete({
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild className={className}>
-        <Button variant="outline" size="xs" disabled={disabled}>
+        {customButton || <Button variant="outline" size="xs" disabled={disabled}>
           <Iconify icon="ph:trash-duotone" />
           <span>{buttonText}</span>
-        </Button>
+        </Button>}
       </AlertDialogTrigger>
 
       <AlertDialogContent>

--- a/app/routes/user.account.tsx
+++ b/app/routes/user.account.tsx
@@ -1,4 +1,3 @@
-import { conform, useForm } from "@conform-to/react"
 import { parse } from "@conform-to/zod"
 import {
   json,
@@ -8,16 +7,13 @@ import {
   type MetaFunction,
 } from "@remix-run/node"
 import {
-  Form,
-  useActionData,
   useLoaderData,
   useNavigation,
 } from "@remix-run/react"
-import { type z } from "zod"
 import { AvatarAuto } from "~/components/ui/avatar-auto"
 
 import { ButtonLoading } from "~/components/ui/button-loading"
-import { Input } from "~/components/ui/input"
+import { FormDelete } from "~/components/shared/form-delete"
 import { requireUser } from "~/helpers/auth"
 import { modelUser } from "~/models/user.server"
 import { schemaGeneralId } from "~/schemas/general"
@@ -39,16 +35,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
 export default function UserAccountRoute() {
   const { user } = useLoaderData<typeof loader>()
-  const lastSubmission = useActionData<typeof action>()
 
   const navigation = useNavigation()
   const isSubmitting = navigation.state === "submitting"
-
-  const [form, { id }] = useForm<z.infer<typeof schemaGeneralId>>({
-    id: "delete-account",
-    lastSubmission,
-    defaultValue: { id: user.id },
-  })
 
   return (
     <div className="app-container">
@@ -69,9 +58,12 @@ export default function UserAccountRoute() {
           </p>
         </header>
 
-        <Form method="POST" {...form.props}>
-          <fieldset disabled={isSubmitting}>
-            <Input {...conform.input(id, { type: "hidden" })} required />
+        <FormDelete
+          action=""
+          intentValue=""
+          itemText={`your account: ${user.fullname} (@${user.username})`}
+          defaultValue={user.id}
+          customButton={
             <ButtonLoading
               type="submit"
               size="sm"
@@ -81,8 +73,8 @@ export default function UserAccountRoute() {
             >
               Delete account
             </ButtonLoading>
-          </fieldset>
-        </Form>
+          }
+        />
       </section>
     </div>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a confirmation pop-up before user account deletion to help reduce the risk of accidental account deletion.

## What is the current behavior?

There is no confirmation, the user account is immediately deleted after clicking the "Delete account" button.

## What is the new behavior?

There is a confirmation pop-up before user account deletion.

![delete-account-confirmation](https://github.com/bandungdevcom/bandungdev.com/assets/39845286/4decd5e2-92db-4498-8475-4f845ec2a9cf)

## Additional context

Resolves #58 
