### PR TITLE
fix: db provider

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,7 @@
 // Visualize with https://prismaliser.app
 
 datasource db {
-  provider     = "mysql"
+  provider     = "postgresql"
   url          = env("DATABASE_URL")
   relationMode = "prisma"
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix can't access staging web because on branch staging still using db provider mysql but the db now is using posgress

## What is the current behavior?

<img width="1440" alt="Screenshot 2024-05-31 at 20 10 46" src="https://github.com/bandungdevcom/bandungdev.com/assets/146088249/6923a28d-c6b8-41b6-9d2b-d53efda9ff1d">

## What is the new behavior?

Change db provider on schema.prisma from mysql to postgresql
